### PR TITLE
fix: Identificado que a logica do firewall estava invertiada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ override.tf.json
 *_override.tf.json
 terraform.inc
 .terraform.lock.hcl
+credentials.json
+key.json
 # Include override files you do wish to add to version control using negated pattern
 #
 # !example_override.tf

--- a/main.tf
+++ b/main.tf
@@ -41,9 +41,9 @@ resource "google_compute_firewall" "firewall_rules" {
   network = google_compute_network.vpc_network.id
   direction          = var.direction
   target_tags        = var.target_tags
-  source_ranges      = var.direction == "EGRESS" ? var.source_ranges : null
-  source_tags        = var.direction == "EGRESS" ? var.source_tags : null
-  destination_ranges = var.direction == "INGRESS" ? var.destination_ranges : null
+  source_ranges      = var.direction == "INGRESS" ? var.source_ranges : null
+  source_tags        = var.direction == "INGRESS" ? var.source_tags : null
+  destination_ranges = var.direction == "EGRESS" ? var.destination_ranges : null
     
   dynamic "allow" {
     for_each = var.firewall_allow

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "firewall_allow" {
   description = "Lista de portas para permitir no firewall"
   type = list(object({
     protocol = string
-    port     = list(number)
+    port     = list(string)
   }))
 }
 


### PR DESCRIPTION
# fix: Identificado que a logica do firewall estava invertida

<!-- Por favor descreva seu pull request aqui. -->

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [ ] Inclua links relevantes para a sua modificação/sugestão/correção
- [ ] Descreva um passo-a-passo para testar o seu PR

## Issue

#11 

## Objetivo

  No if ternario para associação de sources ranges e source tags a logica
  estava invertida, onde o EGRESS estava utilizando as variaveis de origem
  e o INGRESS estava utilizando as variaveis de destino.

  Feita também a correção da variavel firewall_allow que recebe as portas
  do firewall, atualmente ela recebe somente numbers impossibilitando
  receber portas em range. Exemplo 10000 - 15000.

## Referências

<!-- Links relevantes -->

## Como testar

<!-- Passo a passo -->

<!--
Marque um `x` dentro de [ ] para os itens que você forneceu informação
Para modificar este template no seu repositório, basta criar o arquivo .github/pull_request_template.md nele.
-->

Co-authored-by: Marcelo Mansur <mansur.ufmg@gmail.com>
Co-authored-by: Vitor Junior <vitorjr81@gmail.com>
Co-authored-by: Guilherme Xavier <guilherme.lnx@gmail.com>